### PR TITLE
Update a nonexistent proc call to the new version

### DIFF
--- a/qoi_nim.nimble
+++ b/qoi_nim.nimble
@@ -14,5 +14,5 @@ bin           = @["qoi_nim"]
 requires "nim >= 1.6.2"
 
 # just for conv.nim
-requires "pixie >= 3.1.2"
+requires "pixie >= 4.3.0"
 requires "chroma >= 0.2.5"

--- a/src/qoi_nim/conv.nim
+++ b/src/qoi_nim/conv.nim
@@ -17,7 +17,7 @@ proc convert*(fname_in: string, fname_out: string) =
 
   if fname_in.endsWith(".png") and fname_out.endsWith(".qoi"):
     let s = readFile(fname_in)
-    let png = decodePngRaw(s)
+    let png = decodePng(s)
     let desc = QOIDesc(width: png.width.uint32, height: png.height.uint32, channels: png.channels.uint8, colorspace: 0'u8) # TODO colorspace
 
     var imgBytes = newSeq[uint8](png.width * png.height * png.channels)


### PR DESCRIPTION
When trying to use this as a dependency, it failed, because the newer version of pixie I had installed had the proc `decodePng` which appears to supersede `decodePngRaw`. As such, this PR exists.